### PR TITLE
allow Symfony 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,11 +23,11 @@
         "league/tactician-doctrine": "^1.1",
         "ramsey/uuid": "^3.7",
         "sulu/sulu": "^2.0@dev",
-        "symfony/config": "^3.4",
-        "symfony/dependency-injection": "^3.4",
-        "symfony/framework-bundle": "^3.4",
-        "symfony/http-foundation": "^3.4",
-        "symfony/http-kernel": "^3.4"
+        "symfony/config": "^3.4 || ^4.0",
+        "symfony/dependency-injection": "^3.4 || ^4.0",
+        "symfony/framework-bundle": "^3.4 || ^4.0",
+        "symfony/http-foundation": "^3.4 || ^4.0",
+        "symfony/http-kernel": "^3.4 || ^4.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^2.12",


### PR DESCRIPTION
The current `composer.json` doesn't allow Symfony 4 components to be installed, and therefore fails when the latest version of Sulu is used.